### PR TITLE
fix ユーザーランク更新通知が消せない

### DIFF
--- a/backend/app/Http/Actions/User/Notification/RemoveUserRankNoticeAction.php
+++ b/backend/app/Http/Actions/User/Notification/RemoveUserRankNoticeAction.php
@@ -15,7 +15,7 @@ final class RemoveUserRankNoticeAction extends Controller
 {
     public function __invoke(): Redirector|RedirectResponse
     {
-        UserReadNotification::where('id', Auth::id())->update(["is_showed_update_user_rank" => 1]);
+        UserReadNotification::where('user_id', Auth::id())->update(["is_showed_update_user_rank" => 1]);
         return redirect(route('ShowHome'));
     }
 }

--- a/backend/app/Models/Diary.php
+++ b/backend/app/Models/Diary.php
@@ -38,12 +38,12 @@ class Diary extends Model
      * user_idは後で入れるので不要
      *
      */
-    public static $rules = array(
+    public static $rules = [
         "date" => "required",
         "title" => "max:50", //laravelのstringはvarchar(255)なので、255文字まで、しかし入らないから50字に抑える
         "content" => "required|min:1|max:16000", //text型の限界が16384文字なので(マルチバイトで)
         // "user_id"=>"required|numeric",
-    );
+    ];
 
     protected $fillable = [
         "user_id", "uuid", "title", "content", "date", "created_at", "updated_at"

--- a/backend/database/seeders/userReadNotificationTableSeeder.php
+++ b/backend/database/seeders/userReadNotificationTableSeeder.php
@@ -17,7 +17,18 @@ class userReadNotificationTableSeeder extends Seeder
      */
     public function run()
     {
+        /**
+         * idとuser_idが一致しているとバグに気付け無いことがあるので意図的にidとuser_idが合わないようにしている
+         */
         $param = [
+            [
+                'user_id' => 2,
+                "is_showed_update_user_rank" => 0,
+                "is_showed_update_system_info" => 0,
+                "is_showed_service_info" => 0,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
             [
                 'user_id' => 1,
                 "is_showed_update_user_rank" => 0,
@@ -27,14 +38,6 @@ class userReadNotificationTableSeeder extends Seeder
                 'updated_at' => Carbon::now(),
             ],
 
-            [
-                'user_id' => 2,
-                "is_showed_update_user_rank" => 0,
-                "is_showed_update_system_info" => 0,
-                "is_showed_service_info" => 0,
-                'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
-            ],
         ];
         DB::table("user_read_notifications")->insert($param);
     }


### PR DESCRIPTION
ローカルで起こらず本番だけで起きたことが原因

## 理由
ローカルだとユーザーID=ユーザーランクのカラムidになっていたため気づかなかった

## 改善
シーダーでidとuser_idが一致しないように変更