### PR TITLE
fix 統計処理がコケる問題の修正

### DIFF
--- a/backend/python/nlpForDiary.py
+++ b/backend/python/nlpForDiary.py
@@ -3,8 +3,7 @@
 import time
 import json
 import sys
-from datetime import datetime as dt
-from datetime import timezone,timedelta
+from datetime import datetime as dt,timezone,timedelta
 
 from base import connectDBClass as database
 
@@ -45,20 +44,21 @@ def nlpForDiary(user_id):
 
         #個別日記のループ
         if(row[1]!=None):
-            time_updated_at = row[1]#この時点でdatetime型になっている
+            time_updated_at = row[1]#diaries updated_at
         else:
-            # データない場合
-            time_updated_at = time.strptime('1800-1-1 11:11:11', '%Y-%m-%d %H:%M:%S')
+            # データない場合(確実に統計処理を走らせるために、過去の日付を入れる)
+            time_updated_at = time.strptime('1800-1-2 11:11:11', '%Y-%m-%d %H:%M:%S')
         #統計の更新日取得
         if(row[2]!=None):
-            time_statistics_updated_at = row[2]
+            time_statistics_updated_at = row[2]# statistic_per_dates updated_at
         else:
-            # データない場合
+            #新規で空のデータを作成
+            db.create_diary_meta_row('statistic_per_dates',row[0],dt.now(JST))
+            # データない場合(確実に統計処理を走らせるために、過去の日付を入れる)
             time_statistics_updated_at = dt.strptime('1800-1-1 11:11:11','%Y-%m-%d %H:%M:%S')
 
         logic_updated_at = dt.strptime('2021-10-27 21:00:22','%Y-%m-%d %H:%M:%S')
-        #統計の更新がロジック更新後に更新入っているか統計更新してから日記側に変更xがないときは変更しない
-        #falseで実行なので、andに違和感覚えるが、これでいい。
+        #統計の更新がロジック更新後に更新入っているか、統計更新してから日記側に変更がないときは変更しない
         if(time_statistics_updated_at > logic_updated_at and time_statistics_updated_at>time_updated_at):
             #処理不要 リーダーブルコードに乗ってたやつ
             print(str(row[0])+"スキップ")

--- a/backend/python/nlpForTotal.py
+++ b/backend/python/nlpForTotal.py
@@ -133,7 +133,7 @@ def nlpForTotal(user_id):
 
     del db
 
-    print("nlpForMonth終了")
+    print("nlpForTotal終了")
 
 if __name__ == '__main__':
     from_php = sys.argv#php側の引数


### PR DESCRIPTION
# 原因
2重の原因

## 原因1
データがないときにDBに新規で空の行を追加する
→このときにupdated_atに入る値がUTC
↓
統計スキップ処理が働いて、入るべき値が入っていなかった

## 原因2
データがないときにDiaryForPreでStatisticPerDateも作る
→updated_atがこのときの時間になる（ただしデータは入ってない）

DiaryForDiaryで情報確認の際にもうデータ入っている判定がされ、処理がスキップされ入るべき値が入っていなかった


# 気付けなかった原因
途中まで生成していれば、この影響を受けない。
テーブルの分離後に動作確認を行った時はDBを消してからのテストをしていなかった
→これはマイグレーション状況を本番と同じ環境にしたいためだったが、裏目に出た

# todo
まじで早くPythonのコード解体したい、事あるごとに事故る。
バグの温床すぎる。
