### PR TITLE
feat 日記のUTF8エクスポート追加、インポートをUTF8前提に変更

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,7 +37,7 @@
   - docs/arc/*
 📐UML:
   - docs/UML/*
-🧭roadMap:
+🧭roadmap:
   - docs/ROADMAP/*
 
 # 細かいもの

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
         "Redirector",
         "releasenote",
         "releasenotes",
+        "sjis",
         "Tukini"
     ],
     //psr12の自動整形のための設定↓

--- a/backend/app/Http/Actions/Diary/Export/ExportByCsvSJisAction.php
+++ b/backend/app/Http/Actions/Diary/Export/ExportByCsvSJisAction.php
@@ -8,9 +8,8 @@ use App\Models\Diary;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\Str;
-use Log;
 
-class ExportByCsvAction
+class ExportByCsvSJisAction
 {
     public function __invoke(): Redirector|RedirectResponse
     {
@@ -43,12 +42,7 @@ class ExportByCsvAction
         readfile("exportCsv/{$uuid}.csv");
 
         $file = "exportCsv/{$uuid}.csv";
-        if (unlink($file)) {
-            // echo $file.'の削除に成功しました。';
-            Log::debug("{$file}.の削除成功");
-        } else {
-            Log::debug("{$file}.の削除失敗");
-        }
+        unlink($file);
 
         return redirect(route('ShowSetting'));
     }

--- a/backend/app/Http/Actions/Diary/Export/ExportByCsvUtf8Action.php
+++ b/backend/app/Http/Actions/Diary/Export/ExportByCsvUtf8Action.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Actions\Diary\Export;
+
+use App\Models\Diary;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Redirector;
+use Illuminate\Support\Str;
+
+class ExportByCsvUtf8Action
+{
+    public function __invoke(): Redirector|RedirectResponse
+    {
+        $diaries = Diary::orderby('date', 'asc')->select(['date', 'title', 'content'])->get()->toArray();
+        // \Log::debug("message".$diary);
+        // CSVカラムの生成
+        $head = ['日付', 'タイトル', '内容'];
+
+        // 書き込み用ファイルを開く
+        $uuid = Str::uuid();
+        $f = fopen("exportCsv/{$uuid}.csv", 'w');
+        if ($f) {
+            fputcsv($f, $head);
+            // データの書き込み
+            foreach ($diaries as $diary) {
+                fputcsv($f, $diary);
+            }
+        }
+        // ファイルを閉じる
+        fclose($f);
+        // HTTPヘッダ
+        // @todo ここにheaderは責務分割的によろしくない
+        header('Content-Type: application/octet-stream');
+        header('Content-Length: '.filesize("exportCsv/{$uuid}.csv"));
+        header("Content-Disposition: attachment; filename=exportCsv/{$uuid}.csv");
+        readfile("exportCsv/{$uuid}.csv");
+
+        $file = "exportCsv/{$uuid}.csv";
+        unlink($file);
+
+        return redirect(route('ShowSetting'));
+    }
+}

--- a/backend/app/Http/Actions/Diary/Import/ImportFromKadodeCsvAction.php
+++ b/backend/app/Http/Actions/Diary/Import/ImportFromKadodeCsvAction.php
@@ -53,7 +53,7 @@ class ImportFromKadodeCsvAction extends Controller
 
             // 文字コードをUTF-8に変換、CSVのヘッダー行を無視
             $config->setToCharset('UTF-8');
-            $config->setFromCharset('sjis-win');
+            $config->setFromCharset('UTF-8');
             $config->setIgnoreHeaderLine(true);
 
             /** @var array<array{date:string,title:string,content:string}> */

--- a/backend/resources/views/diary/setting.blade.php
+++ b/backend/resources/views/diary/setting.blade.php
@@ -687,7 +687,7 @@
 
             <div class="settingContent md:w-1/2 w-full">
                 <h4 class="text-xl text-center mt-4">かどで日記形式の<br class="md:hidden">CSVファイル</h4>
-                <p class="text-sm text-center mb-4">かどで日記からエクスポートしていないものは動作保証外です</p>
+                <p class="text-sm text-center mb-4">かどで日記から文字コード:UTF-8でエクスポートしたCSVファイルのみが動作対象です</p>
                 <form class="text-center flex justify-center flex-wrap flex-col " method="POST"
                     enctype="multipart/form-data" action="{{route('ImportFromKadodeCsv')}}">
                     {{-- エラー --}}
@@ -733,13 +733,28 @@
     </div>
     <div class="setting">
         @include('components.settingHeading',['title'=>'日記のエクスポート'])
-        <p class="text-sm text-center kiwi-maru">※エクスポート時に文字コードをutf-8からWindows-31J(拡張Shift-JIS)に変換してCSVを作成します</p>
-        <div class="settingContentWrapper">
-            <form class="flex justify-center flex-wrap flex-col " method="POST" action="{{route('ExportByCsv')}}">
-                @csrf
-                <input type="submit" class="text-black px-2 md:w-1/2 w-full mx-auto bg-kn_2" value="csv形式でエクスポート">
-            </form>
-            {{-- <div class="settingContent"><a href="/export/diary">CSVエクスポート</a></div> --}}
+        <div class="settingContentWrapper flex justify-center items-center flex-wrap">
+            <div class="settingContent md:w-1/2 w-full">
+                <h4 class="text-xl text-center mt-4">CSVファイル(推奨)<br><span class="text-base">文字コード:UTF-8</h4>
+                <p class="text-sm text-center mb-4">
+                    かどで日記の内部と同じ文字コードのためデータの復元が可能ですがMSExcelなどでは文字化けします。</p>
+                <form class="flex justify-center flex-wrap flex-col " method="POST"
+                    action="{{route('ExportByCsvUtf8')}}">
+                    @csrf
+                    <input type="submit" class="text-black px-2 md:w-1/2 w-full mx-auto bg-kn_2" value="エクスポート">
+                </form>
+            </div>
+            <div class="settingContent md:w-1/2 w-full">
+                <h4 class="text-xl text-center mt-4">CSVファイル(非推奨)<br><span class="text-base">文字コード:拡張Shift-JIS</span>
+                </h4>
+                <p class="text-sm text-center mb-4">
+                    かどで日記はutf8mb4で保存されています。この文字コードを選択した場合、MSExcelなどで文字化けせず開けますが一部の文字が壊れます。</p>
+                <form class="flex justify-center flex-wrap flex-col " method="POST"
+                    action="{{route('ExportByCsvSJis')}}">
+                    @csrf
+                    <input type="submit" class="text-black px-2 md:w-1/2 w-full mx-auto bg-kn_2" value="エクスポート">
+                </form>
+            </div>
         </div>
     </div>
     <div class="setting">

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -73,10 +73,12 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function (): void {
     // 検索
     Route::post('/search', \App\Http\Actions\Diary\Search\SimpleSearchAction::class)->name('SimpleSearch');
     Route::get('/search', \App\Http\Actions\Diary\Search\ShowSimpleSearchAction::class)->name('ShowSimpleSearch');
-    // 日記の入出力
+    // 日記のインポート
     Route::post('/import/diary/kadode', \App\Http\Actions\Diary\Import\ImportFromKadodeCsvAction::class)->name('ImportFromKadodeCsv');
     Route::post('/import/diary/tukini', \App\Http\Actions\Diary\Import\ImportFromTukiniTxtAction::class)->name('ImportFromTukiniTxt');
-    Route::post('/export/diary', \App\Http\Actions\Diary\Export\ExportByCsvAction::class)->name('ExportByCsv');
+    // 日記のエクスポート
+    Route::post('/export/diary/csv/sjis', \App\Http\Actions\Diary\Export\ExportByCsvSJisAction::class)->name('ExportByCsvSJis');
+    Route::post('/export/diary/csv/utf8', \App\Http\Actions\Diary\Export\ExportByCsvUtf8Action::class)->name('ExportByCsvUtf8');
     // セキュリティ
     Route::middleware(['password.confirm'])->group(function (): void {
         Route::get('/security', \App\Http\Actions\ShowSecurityAction::class)->name('ShowSecurity');


### PR DESCRIPTION
これまで謎にWindowsを優遇してしまったが、ちゃんと復元できるUTF8も用意する