### PR TITLE
fix GCPの認証をenvからconfigの変更に対応

### DIFF
--- a/backend/app/Console/Commands/GCSCommand.php
+++ b/backend/app/Console/Commands/GCSCommand.php
@@ -36,8 +36,13 @@ class GCSCommand extends Command
      */
     public function handle(): int
     {
-        $client = new StorageClient();
-        $bucket = $client->bucket(config('gcs.packet')); // 作成したバケット
+        $packetName = config('gcs.packet');
+        $url = file_get_contents(config('gcs.keyPath'));
+        $client = new StorageClient([
+            'projectId' => $packetName,
+            'keyFile' => json_decode($url, true),
+        ]);
+        $bucket = $client->bucket($packetName); // 作成したバケット
 
         /**
          * ディレクトリハンドルの取得.

--- a/backend/config/gcs.php
+++ b/backend/config/gcs.php
@@ -5,4 +5,7 @@ declare(strict_types=1);
 return [
     // GCP google could storageのパケット名
     'packet' => env('GCS_PACKET', 'kadode'),
+    'keyPath' => env('GOOGLE_APPLICATION_CREDENTIALS', ''),
+    // 'notificationEmail' => env('BACKUP_NOTIFICATION_EMAIL_TO', ''),
+    // 'uploadBackupPath' => env('SERVER_BACKUP_PATH', ''),
 ];


### PR DESCRIPTION
# やったこと
明示的にjsonファイルを指定するように変更

# 備考
confiをenvでなくキャッシュから読む方式に変更したときに、GCPのライブラリがデフォルトのままでは対応できていなかった

