### PR TITLE
feat お知らせ取得を生やす

### DIFF
--- a/backend/app/Http/ApiActions/Osirase/GetAllOsiraseAction.php
+++ b/backend/app/Http/ApiActions/Osirase/GetAllOsiraseAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\ApiActions\Osirase;
+
+use App\Http\Controllers\Controller;
+use App\Models\Osirase;
+use Illuminate\Http\JsonResponse;
+
+final class GetAllOsiraseAction extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        /** @todo お知らせの個別ページがないので、現状お知らせ一覧をリンク先にしているため、個別ページできたら差し替え */
+        $url = route('ShowOsirase');
+        $osirases = Osirase::orderBy('date', 'desc')->get(['title', 'date', 'description']);
+
+        return response()->json(
+            array_map(function ($osirase) use ($url) {
+                $osirase['url'] = $url;
+
+                return $osirase;
+            }, $osirases->toArray())
+        );
+    }
+}

--- a/backend/app/Http/ApiActions/Osirase/GetLatestOsiraseAction.php
+++ b/backend/app/Http/ApiActions/Osirase/GetLatestOsiraseAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\ApiActions\Osirase;
+
+use App\Http\Controllers\Controller;
+use App\Models\Osirase;
+use Illuminate\Http\JsonResponse;
+
+final class GetLatestOsiraseAction extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        /** @todo お知らせの個別ページがないので、現状お知らせ一覧をリンク先にしているため、個別ページできたら差し替え */
+        $url = route('ShowOsirase');
+        $osirases = Osirase::orderBy('date', 'desc')->limit(5)->get(['title', 'date', 'description']);
+
+        return response()->json(
+            // osirasesとurlを合体させる
+            array_map(function ($osirase) use ($url) {
+                $osirase['url'] = $url;
+
+                return $osirase;
+            }, $osirases->toArray())
+        );
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -20,8 +20,14 @@ Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $reques
 
 Route::get('/', App\Http\ApiActions\GetApiStatus::class)->name('getApiStatus');
 
+// ユーザー、日記、統計の取得API
 Route::get('OperationCoreTransitionPerHours/relative/day', \App\Http\ApiActions\OperationCoreTransition\GetOperationCoreTransitionLatestDay::class)->name('GetOperationCoreTransitionLatestDay');
 Route::get('OperationCoreTransitionPerHours/relative/week', \App\Http\ApiActions\OperationCoreTransition\GetOperationCoreTransitionLatestWeek::class)->name('GetOperationCoreTransitionLatestWeek');
 Route::get('OperationCoreTransitionPerHours/relative/month', \App\Http\ApiActions\OperationCoreTransition\GetOperationCoreTransitionLatestMonth::class)->name('GetOperationCoreTransitionLatestMonth');
 
+// サーバーのリソース取得API
 Route::get('MachineResource/relative/30min', \App\Http\ApiActions\MachineResource\GetMachineResourceLatest30Minutes::class)->name('GetMachineResourceLatest30Minutes');
+
+// お知らせ一覧取得API
+Route::get('Osirase/all', \App\Http\ApiActions\Osirase\GetAllOsiraseAction::class)->name('GetAllOsiraseAction');
+Route::get('Osirase/latest', \App\Http\ApiActions\Osirase\GetLatestOsiraseAction::class)->name('GetLatestOsiraseAction');


### PR DESCRIPTION
# やったこと
お知らせ取得APIを生やした
# 備考
URLが課題
かどでポータル側でnote側と合わせたいことを考えると、お知らせの個別ページが欲しくなる

# スクリーンショット(任意)
