### PR TITLE
fix 月単位の取得系APIでのDB叩きは1日1件までの取得に制限

### DIFF
--- a/backend/app/Http/ApiActions/MachineResource/GetMachineResourceLatestMonth.php
+++ b/backend/app/Http/ApiActions/MachineResource/GetMachineResourceLatestMonth.php
@@ -15,7 +15,8 @@ final class GetMachineResourceLatestMonth extends Controller
     {
         return response()->json(
             // idが遅いほど新しいデータなのでidの降順にすることで手前ほど新しいデータにする
-            MachineResource::where('created_at', '>=', Carbon::now()->subMonth())->orderBy('id', 'desc')->get()
+            // 1時間ごとだと月ごとのデータが多すぎるので、1日1つに制限する(date('G')で現在時間を取得できるので各日リクエストした時間帯の値を取ってくることで直近のデータとの齟齬を無くす)
+            MachineResource::where('created_at', '>=', Carbon::now()->subMonth())->whereRaw('hour(created_at) = ?', [date('G')])->orderBy('id', 'desc')->get()
         );
     }
 }

--- a/backend/app/Http/ApiActions/OperationCoreTransition/GetOperationCoreTransitionLatestMonth.php
+++ b/backend/app/Http/ApiActions/OperationCoreTransition/GetOperationCoreTransitionLatestMonth.php
@@ -15,7 +15,8 @@ final class GetOperationCoreTransitionLatestMonth extends Controller
     {
         return response()->json(
             // idが遅いほど新しいデータなのでidの降順にすることで手前ほど新しいデータにする
-            OperationCoreTransitionPerHour::where('created_at', '>=', Carbon::now()->subMonth())->orderBy('id', 'desc')->get()
+            // 1時間ごとだと月ごとのデータが多すぎるので、1日1つに制限する(date('G')で現在時間を取得できるので各日リクエストした時間帯の値を取ってくることで直近のデータとの齟齬を無くす)
+            OperationCoreTransitionPerHour::where('created_at', '>=', Carbon::now()->subMonth())->whereRaw('hour(created_at) = ?', [date('G')])->orderBy('id', 'desc')->get()
         );
     }
 }


### PR DESCRIPTION
タイトルの通り。

月単位の取得APIで24*30=720件取得する処理がちょっと重たいので。
マシンリソースはこの倍になるので、日あたり1つまでに制限する。

使う目的にもグラフ描画用なので1日1件で十分。