### PR TITLE
feat phpとnginxをまとめて1つに統合

### DIFF
--- a/compose-prod.yml
+++ b/compose-prod.yml
@@ -10,6 +10,8 @@ services:
       dockerfile: ./infra/prod/container/backend/Dockerfile
     tty: true
     stdin_open: true
+    ports:
+      - "2010:2010"
     volumes:
       - type: bind
         source: ./backend/storage
@@ -88,16 +90,6 @@ services:
       - "2000:2000"
     user: "1000:1000"
     # command: sh -c "pnpm install"
-
-  nginx:
-    build:
-      context: .
-      dockerfile: ./infra/prod/container/nginx/Dockerfile
-    ports:
-      - "2010:2010"
-    depends_on:
-      - "backend"
-      - "frontend"
 
   db: # 3306port
     build:

--- a/compose.yml
+++ b/compose.yml
@@ -22,6 +22,8 @@ services:
     depends_on:
       - "db"
       - "redis"
+    ports:
+      - "2010:2010"
     environment:
       - APP_NAME=かどで日記3
       - APP_ENV=local
@@ -96,20 +98,6 @@ services:
       - ./frontend:/frontend
     # command: sh -c "pnpm install"
 
-  nginx:
-    build:
-      context: .
-      dockerfile: ./infra/dev/container/nginx/Dockerfile
-    ports:
-      - "2010:2010"
-    depends_on:
-      - "backend"
-      - "frontend"
-    volumes:
-      - type: bind
-        source: ./backend
-        target: /work/backend
-
   db: # 3306 port
     build:
       context: .
@@ -161,6 +149,4 @@ services:
     ports:
       - 4444:4444
       - 5900:5900
-    depends_on:
-      - nginx
     privileged: true

--- a/infra/dev/container/backend/Dockerfile
+++ b/infra/dev/container/backend/Dockerfile
@@ -23,11 +23,18 @@ RUN apt-get update \
     libonig-dev \
     gnupg \
     clang \
+    nginx \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && locale-gen en_US.UTF-8 \
   && localedef -f UTF-8 -i en_US en_US.UTF-8 \
   && mkdir /var/run/php-fpm
+
+#
+# nginx関連
+#
+COPY infra/dev/container/backend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY infra/dev/container/backend/entrypoint.sh /etc/entrypoint.sh
 
 #
 # GRPC関連のインストール
@@ -73,3 +80,5 @@ RUN composer config -g process-timeout 3600 && composer config -g repos.packagis
 COPY ./infra/dev/container/backend/php.ini /usr/local/etc/php/php.ini
 
 WORKDIR /work/backend
+
+ENTRYPOINT ["/etc/entrypoint.sh"]

--- a/infra/dev/container/backend/entrypoint.sh
+++ b/infra/dev/container/backend/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+
+php-fpm -D
+nginx -g 'daemon off;'

--- a/infra/dev/container/backend/nginx.conf
+++ b/infra/dev/container/backend/nginx.conf
@@ -1,8 +1,3 @@
-# このファイルを編集したときは、コンテナごと作り直す！！(ADDしてるので、変更がコンテナ変えないと反映されない)
-access_log /dev/stdout main;
-error_log /dev/stderr warn;
-
-# バックエンド
 server {
     listen 2010;
     root /work/backend/public;
@@ -11,7 +6,7 @@ server {
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options "nosniff";
     client_max_body_size 100M;
-    index index.html index.htm index.php;
+    index index.php;
 
     charset utf-8;
 
@@ -25,8 +20,7 @@ server {
     error_page 404 /index.php;
 
     location ~ \.php$ {
-        fastcgi_pass unix:/var/run/php-fpm/php-fpm.sock;
-        fastcgi_index index.php;
+        fastcgi_pass localhost:9000; # デフォルトだと9000ポートになるらしい
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
     }

--- a/infra/dev/container/nginx/Dockerfile
+++ b/infra/dev/container/nginx/Dockerfile
@@ -1,9 +1,0 @@
-FROM nginx:stable-alpine
-COPY infra/dev/container/nginx/nginx.conf /etc/nginx/conf.d/default.conf
-
-RUN apk update && \
-    apk add --update --no-cache --virtual=.build-dependencies g++
-
-RUN apk add bash
-
-WORKDIR /work/backend

--- a/infra/prod/container/backend/Dockerfile
+++ b/infra/prod/container/backend/Dockerfile
@@ -20,11 +20,19 @@ RUN apt-get update \
     libicu-dev \
     libonig-dev \
     gnupg \
+    nginx \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && locale-gen en_US.UTF-8 \
   && localedef -f UTF-8 -i en_US en_US.UTF-8 \
   && mkdir /var/run/php-fpm
+
+#
+# nginx関連
+#
+COPY infra/prod/container/backend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY infra/prod/container/backend/entrypoint.sh /etc/entrypoint.sh
+
 
 #
 # PHP関連のインストール
@@ -38,7 +46,7 @@ RUN MAKEFLAGS="-j $(nproc)" pecl install grpc protobuf \
 RUN composer config -g process-timeout 3600 && composer config -g repos.packagist composer https://packagist.org
 
 
-COPY ./infra/dev/container/backend/php.ini /usr/local/etc/php/php.ini
+COPY ./infra/prod/container/backend/php.ini /usr/local/etc/php/php.ini
 
 WORKDIR /work/backend
 
@@ -70,3 +78,5 @@ RUN chmod -R 777 storage bootstrap/cache \
     && php artisan view:cache \
     && php artisan optimize
 # 終了させないために
+
+ENTRYPOINT ["/etc/entrypoint.sh"]

--- a/infra/prod/container/backend/entrypoint.sh
+++ b/infra/prod/container/backend/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+
+php-fpm -D
+nginx -g 'daemon off;'

--- a/infra/prod/container/backend/nginx.conf
+++ b/infra/prod/container/backend/nginx.conf
@@ -1,8 +1,3 @@
-# このファイルを編集したときは、コンテナごと作り直す！！(ADDしてるので、変更がコンテナ変えないと反映されない)
-access_log /dev/stdout main;
-error_log /dev/stderr warn;
-
-# バックエンド
 server {
     listen 2010;
     root /work/backend/public;
@@ -11,7 +6,7 @@ server {
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options "nosniff";
     client_max_body_size 100M;
-    index index.php;
+    index index.html index.htm index.php;
 
     charset utf-8;
 
@@ -25,7 +20,7 @@ server {
     error_page 404 /index.php;
 
     location ~ \.php$ {
-        fastcgi_pass backend:9000; # デフォルトだと9000ポートになるらしい
+        fastcgi_pass localhost:9000; # デフォルトだと9000ポートになるらしい
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
     }

--- a/infra/prod/container/nginx/Dockerfile
+++ b/infra/prod/container/nginx/Dockerfile
@@ -1,6 +1,0 @@
-FROM nginx:stable-alpine
-COPY infra/dev/container/nginx/nginx.conf /etc/nginx/conf.d/default.conf
-
-WORKDIR /work/backend
-
-COPY ./backend/public ./public


### PR DESCRIPTION
本来1コンテナにすべきでないが、phpが単体でHTTPリクエスト・レスポンス投げるの難しいため(簡易サーバーよりはマシ)
k8sの管理的にこの方がスケールしやすいため